### PR TITLE
fix(slime): use lowercase sglang log level so the rollout HTTP server starts

### DIFF
--- a/3.test_cases/pytorch/slime/recipe/run_grpo_qwen3_30b_a3b.sh
+++ b/3.test_cases/pytorch/slime/recipe/run_grpo_qwen3_30b_a3b.sh
@@ -138,7 +138,11 @@ TRAIN_ARGS=(
     --rollout-num-gpus-per-engine "${ROLLOUT_GPUS_PER_ENGINE}"
 
     --sglang-mem-fraction-static 0.85
-    --sglang-log-level WARN
+    # SGLang forwards this to uvicorn's log_level, which only accepts lowercase
+    # (critical/error/warning/info/debug/trace). Uppercase "WARN" raises a
+    # KeyError and uvicorn dies before the rollout HTTP server binds, so the
+    # rollout health check never passes and training hangs before it starts.
+    --sglang-log-level info
     --sglang-enable-ep-moe
 )
 

--- a/3.test_cases/pytorch/slime/recipe/run_grpo_qwen3_30b_a3b.sh
+++ b/3.test_cases/pytorch/slime/recipe/run_grpo_qwen3_30b_a3b.sh
@@ -138,11 +138,13 @@ TRAIN_ARGS=(
     --rollout-num-gpus-per-engine "${ROLLOUT_GPUS_PER_ENGINE}"
 
     --sglang-mem-fraction-static 0.85
-    # SGLang forwards this to uvicorn's log_level, which only accepts lowercase
-    # (critical/error/warning/info/debug/trace). Uppercase "WARN" raises a
-    # KeyError and uvicorn dies before the rollout HTTP server binds, so the
-    # rollout health check never passes and training hangs before it starts.
-    --sglang-log-level info
+    # SGLang forwards this to uvicorn's log_level, whose LOG_LEVELS dict is keyed
+    # by lowercase names only (critical/error/warning/info/debug/trace) with no
+    # "warn" key. Uppercase "WARN" (the original value) raises a KeyError and
+    # uvicorn dies before the rollout HTTP server binds, so the rollout health
+    # check never passes and training hangs before it starts. Use lowercase
+    # "warning" to preserve the original intended verbosity.
+    --sglang-log-level warning
     --sglang-enable-ep-moe
 )
 

--- a/3.test_cases/pytorch/slime/recipe/run_grpo_qwen3_4b.sh
+++ b/3.test_cases/pytorch/slime/recipe/run_grpo_qwen3_4b.sh
@@ -137,11 +137,13 @@ TRAIN_ARGS=(
     --rollout-num-gpus-per-engine "${ROLLOUT_GPUS_PER_ENGINE}"
 
     --sglang-mem-fraction-static 0.8
-    # SGLang forwards this to uvicorn's log_level, which only accepts lowercase
-    # (critical/error/warning/info/debug/trace). Uppercase "WARN" raises a
-    # KeyError and uvicorn dies before the rollout HTTP server binds, so the
-    # rollout health check never passes and training hangs before it starts.
-    --sglang-log-level info
+    # SGLang forwards this to uvicorn's log_level, whose LOG_LEVELS dict is keyed
+    # by lowercase names only (critical/error/warning/info/debug/trace) with no
+    # "warn" key. Uppercase "WARN" (the original value) raises a KeyError and
+    # uvicorn dies before the rollout HTTP server binds, so the rollout health
+    # check never passes and training hangs before it starts. Use lowercase
+    # "warning" to preserve the original intended verbosity.
+    --sglang-log-level warning
 )
 
 # Submit via Ray job API.

--- a/3.test_cases/pytorch/slime/recipe/run_grpo_qwen3_4b.sh
+++ b/3.test_cases/pytorch/slime/recipe/run_grpo_qwen3_4b.sh
@@ -137,7 +137,11 @@ TRAIN_ARGS=(
     --rollout-num-gpus-per-engine "${ROLLOUT_GPUS_PER_ENGINE}"
 
     --sglang-mem-fraction-static 0.8
-    --sglang-log-level WARN
+    # SGLang forwards this to uvicorn's log_level, which only accepts lowercase
+    # (critical/error/warning/info/debug/trace). Uppercase "WARN" raises a
+    # KeyError and uvicorn dies before the rollout HTTP server binds, so the
+    # rollout health check never passes and training hangs before it starts.
+    --sglang-log-level info
 )
 
 # Submit via Ray job API.


### PR DESCRIPTION
## Purpose

Second fix in the epic to run the SLIME GRPO test case end-to-end on B300 / H200 (tracked by #1163). This merges into the epic branch `epic/enable-slime-grpo-on-b300-h200`, not into `main` directly; the epic is what goes to upstream in #1164.

Depends on the launcher fix already in the epic (without it, training does not even start, so this wall is not reached). Diff here is only the two recipe files.

## Changes

After the launcher fix, `train.py` starts, then stalls: the SGLang scheduler/engine core come up and sit idle, but the rollout HTTP server never binds. `/health_generate` is unreachable and the GPUs stay at 0% utilization, with no actionable error.

Root cause — an uppercase log level that uvicorn rejects. The recipes pass `--sglang-log-level WARN` (uppercase). SLIME forwards the value verbatim into SGLang's `ServerArgs`, and SGLang hands it to uvicorn as `log_level="WARN"`. uvicorn's `LOG_LEVELS` dict is keyed by lowercase names only (`critical/error/warning/info/debug/trace`) with no `warn` key, so `LOG_LEVELS["WARN"]` raises `KeyError` while uvicorn builds its `Config` — before the socket binds. The HTTP server therefore never comes up, and the RolloutManager waits forever on an unreachable `/health_generate`.

This is generation-independent (an argument-value + uvicorn behavior, not GPU-specific) and reproduces on the documented p5/HyperPod path too. The proper normalization belongs upstream in SGLang, which accepts `WARN` for its own stdlib logger (`getattr(logging, ...upper())`) but forwards it unnormalized to uvicorn; that is filed separately upstream. This recipe change is the immediate unblock.

The change: use lowercase `warning` in both `recipe/run_grpo_qwen3_4b.sh` and `recipe/run_grpo_qwen3_30b_a3b.sh`, with a comment explaining why. `warning` (not `info`) is chosen to preserve the original intended verbosity of `WARN`; uvicorn accepts `warning` as-is (its `LOG_LEVELS` has a `warning` key). Nothing else changes.

Implementation (the exact lines this PR changes):

- `recipe/run_grpo_qwen3_4b.sh` — https://github.com/littlemex/awsome-distributed-training/blob/f3d5dbe/3.test_cases/pytorch/slime/recipe/run_grpo_qwen3_4b.sh#L140-L146
- `recipe/run_grpo_qwen3_30b_a3b.sh` — https://github.com/littlemex/awsome-distributed-training/blob/f3d5dbe/3.test_cases/pytorch/slime/recipe/run_grpo_qwen3_30b_a3b.sh#L141-L147
- Commit — https://github.com/littlemex/awsome-distributed-training/commit/f3d5dbe

## Test Plan

The failure is deterministic and lives entirely inside uvicorn's argument parsing, so
the primary test proves the exact cause and the exact fix with no GPU, no Ray job, and
no dependence on cluster state. A second, end-to-end check on real hardware confirms the
same thing under a live run.

### 1. Root-cause test (deterministic, no GPU / no running job)

This asks uvicorn — the same version shipped in the test-case image (`0.49.0`) — to build
its logging `Config` for each candidate value, exactly as SGLang does when it starts the
rollout server. It isolates the one line that matters: `WARN` (the original recipe value)
throws before the socket can bind; `warning` (this fix) is accepted.

Run it in any pod on the image (worker shown here):

```bash
export NAMESPACE=<your-namespace>
WPOD=$(kubectl -n "$NAMESPACE" get pod -l ray.io/group=gpu-workers -o jsonpath='{.items[0].metadata.name}')

kubectl -n "$NAMESPACE" exec "$WPOD" -c ray-worker -- bash -lc 'python3 -c "
import uvicorn
from uvicorn.config import LOG_LEVELS, Config
print(f\"uvicorn {uvicorn.__version__}; LOG_LEVELS keys = {sorted(LOG_LEVELS)}\")
for lvl in [\"WARN\", \"warn\", \"warning\", \"info\"]:
    try:
        Config(app=\"x:x\", log_level=lvl).configure_logging()
        print(f\"  {lvl:<8} -> OK (accepted; HTTP server can bind)\")
    except Exception as e:
        print(f\"  {lvl:<8} -> {type(e).__name__}: {e} (dies before bind; rollout hangs)\")
"'
```

Expected output (this is the whole proof — `WARN` is rejected, `warning` is accepted):

```
uvicorn 0.49.0; LOG_LEVELS keys = ['critical', 'debug', 'error', 'info', 'trace', 'warning']
  WARN     -> KeyError: 'warn' (dies before bind; rollout hangs)
  warn     -> KeyError: 'warn' (dies before bind; rollout hangs)
  warning  -> OK (accepted; HTTP server can bind)
  info     -> OK (accepted; HTTP server can bind)
```

### 2. End-to-end confirmation on hardware (optional; requires GPUs)

The one-shot block below runs inside the Ray head pod: it launches the `warning`
recipe, **waits by itself** until a rollout HTTP server binds and `/health_generate`
returns 200 (uvicorn binds to the worker's own IP, so it probes that IP, not
`localhost`), asserts that no uvicorn log-level `KeyError` appeared, then stops the job
to free the GPUs. No files are added anywhere — it is streamed in over `bash -s` and
cleaned up on exit. A run with no live job would leave every port unbound and every
probe at `000`, which is why the check drives the job itself rather than assuming one is
running.

```bash
export NAMESPACE=<your-namespace>
HEAD=$(kubectl -n "$NAMESPACE" get pod -l ray.io/node-type=head -o jsonpath='{.items[0].metadata.name}')

kubectl -n "$NAMESPACE" exec -i "$HEAD" -- bash -s <<'EOS'
set -uo pipefail
RECIPE_DIR=/fsx/ref/next-wall; RECIPE=recipe/run_grpo_qwen3_4b.sh
ENV_FILE=/fsx/ref/fix-verify/env_vars.upstream; RAY_ADDR=http://127.0.0.1:8265
PORTS="15000 15002 15004 15006 15008 15010 15012 15014"; BIND_TIMEOUT=360
RC=0; say(){ echo "[verify] $*"; }; fail(){ echo "[verify][FAIL] $*"; RC=1; }

say "launching warning recipe and waiting up to ${BIND_TIMEOUT}s for health 200..."
JOBLOG=$(mktemp); ENGLOG=$(mktemp)
( cd "$RECIPE_DIR" && ENV_FILE="$ENV_FILE" nohup bash "$RECIPE" > "$JOBLOG" 2>&1 & )
JID=""; for i in $(seq 1 30); do JID=$(grep -oE 'raysubmit_[A-Za-z0-9]+' "$JOBLOG" | head -1); [ -n "$JID" ] && break; sleep 2; done
[ -z "$JID" ] && { echo "[verify][FAIL] no job id"; echo "[verify] VERDICT=FAIL"; exit 1; }
say "submitted $JID"

WIP=""; HIT=""; T0=$SECONDS
while [ $((SECONDS-T0)) -lt $BIND_TIMEOUT ]; do
  ST=$(ray job status "$JID" --address "$RAY_ADDR" 2>/dev/null | grep -oE '(RUNNING|SUCCEEDED|FAILED|STOPPED)' | tail -1)
  ray job logs "$JID" --address "$RAY_ADDR" > "$ENGLOG" 2>/dev/null || true   # engine logs live here, not in the submit stdout
  [ -z "$WIP" ] && WIP=$(grep -oE 'ip=[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' "$ENGLOG" | head -1 | cut -d= -f2)
  if [ -n "$WIP" ]; then for p in $PORTS; do
      c=$(curl -s -m 2 "http://$WIP:$p/health_generate" -o /dev/null -w '%{http_code}' 2>/dev/null)
      [ "$c" = "200" ] && { HIT="t=$((SECONDS-T0))s ip=$WIP port=$p"; break; }; done; fi
  [ -n "$HIT" ] && break
  { [ "$ST" = "FAILED" ] || [ "$ST" = "STOPPED" ]; } && { say "job ended ($ST) before 200"; break; }
  sleep 5
done
ray job logs "$JID" --address "$RAY_ADDR" > "$ENGLOG" 2>/dev/null || true

if [ -n "$HIT" ]; then say "PASS: rollout HTTP server answered 200 ($HIT)"
elif grep -qE "KeyError: 'warn'|LOG_LEVELS\[" "$ENGLOG"; then fail "uvicorn log-level KeyError -> fix not effective"
elif grep -qE "cannot be accessed from Triton|libcudart.so.12" "$ENGLOG"; then say "INCONCLUSIVE: engine crashed on a later, unrelated wall (cu13), no log-level KeyError"
else fail "no 200 within ${BIND_TIMEOUT}s and no known failure signature"; fi
grep -qE "KeyError: 'warn'|LOG_LEVELS\[" "$ENGLOG" && fail "found a uvicorn log-level KeyError" || say "no uvicorn log-level KeyError (expected with the fix)"

say "stopping $JID to free GPUs"; ray job stop "$JID" --address "$RAY_ADDR" >/dev/null 2>&1 || true
rm -f "$JOBLOG" "$ENGLOG"
echo "[verify] VERDICT=$([ $RC -eq 0 ] && echo PASS || echo FAIL)"; exit $RC
EOS
```

Expected tail (a live H200 run; the bind time varies with CUDA-graph capture):

```
[verify] launching warning recipe and waiting up to 360s for health 200...
[verify] submitted raysubmit_XXXXXXXX
[verify] PASS: rollout HTTP server answered 200 (t=123s ip=10.3.230.175 port=15008)
[verify] no uvicorn log-level KeyError (expected with the fix)
[verify] stopping raysubmit_XXXXXXXX to free GPUs
[verify] VERDICT=PASS
```

## Test Results

Root-cause test (image uvicorn `0.49.0`, deterministic):

| `--sglang-log-level` | uvicorn `Config` | consequence |
| --- | --- | --- |
| `WARN` (original recipe value) | `KeyError: 'warn'` | dies before bind — rollout hangs |
| `warn` | `KeyError: 'warn'` | dies before bind — rollout hangs |
| `warning` (this fix) | accepted | HTTP server binds |
| `info` | accepted | HTTP server binds |

End-to-end on H200 (2x `p5en.48xlarge`) after the fix:

| check | `WARN` (before) | `warning` (this fix) |
| --- | --- | --- |
| ports 15000-15014 | none bound | all 8 bound (python3 / uvicorn) |
| `/health_generate` | HTTP 000 | HTTP 200 |
| job log | `KeyError: 'warn'` traceback | no log-level error |

Note on log output: at `warning` verbosity uvicorn suppresses its own
`INFO: Uvicorn running ...` line by design, so the e2e check is the bound socket plus a 200
from the health endpoint, not that log line.

## Checklist

- [x] I have read the contributing guidelines.
- [x] I am working against the epic branch (not `main` directly).
- [x] The change is minimal and self-contained (two recipe files).
- [x] External dependencies are pinned to a specific version or tag (no `latest`).
- [x] Verified on hardware (H200): `WARN` hangs, `warning` brings up the rollout HTTP server and passes `/health_generate`.
