### PR TITLE
fix(slime): heal the CUDA-13 torch_memory_saver LD_PRELOAD selection without forking SLIME

### DIFF
--- a/3.test_cases/pytorch/slime/README.md
+++ b/3.test_cases/pytorch/slime/README.md
@@ -522,6 +522,8 @@ slime/                                    # 3.test_cases/pytorch/slime
 ├── env_vars.colocated.example           # Base config: colocated train+rollout, built-in reward
 ├── env_vars.disaggregated.example       # Overlay: reward model on a CPU pool + heavier GRPO
 ├── slime.Dockerfile                     # SLIME + SGLang + Megatron + EFA image
+├── patches/
+│   └── apply_slime_patches.py           # Self-neutralizing in-place fixes for the pinned upstream SLIME checkout (no-op once upstream merges them)
 ├── requirements.txt                     # Pinned Python RL dependencies
 ├── reward_service.Dockerfile            # CPU-only image for the remote reward service
 ├── reward_service/

--- a/3.test_cases/pytorch/slime/patches/apply_slime_patches.py
+++ b/3.test_cases/pytorch/slime/patches/apply_slime_patches.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+"""Self-neutralizing patches for the pinned upstream SLIME checkout.
+
+This test case installs SLIME straight from upstream (``THUDM/slime`` at the
+pinned ``SLIME_VERSION`` -- no fork, no forked URL). A handful of upstream bugs
+still block a clean end-to-end run on B300 / H200 (CUDA 13). Rather than fork
+SLIME or hard-code a fork URL, this script applies each fix *in place* against
+the upstream checkout, and only when the unfixed pattern is actually present.
+
+Design goals (why this shape):
+  * Default is upstream. The image installs upstream SLIME as-is; this runs
+    afterwards as a thin, auditable layer.
+  * Self-neutralizing. Every patch first checks whether the upstream code still
+    exhibits the bug. Once upstream merges the corresponding fix, the pattern is
+    gone and the patch becomes a no-op automatically -- nothing to remember, no
+    version pin to bump, no fork to track. Upstream simply wins.
+  * Idempotent. Re-running (or running against an already-patched tree) is safe;
+    an applied patch is detected and skipped.
+  * Minimal blast radius. Each patch is scoped to the smallest possible edit and
+    is a no-op unless its exact precondition matches, so an unexpected upstream
+    refactor makes the patch skip (and say so) rather than corrupt the file.
+
+Each patch links to the upstream issue/PR that will make it unnecessary. When
+all patches report "already fixed upstream", this file can be deleted.
+
+Usage (from the Dockerfile, right after the upstream SLIME install):
+    python3 patches/apply_slime_patches.py --slime-root /opt/slime
+
+Exit code is 0 whenever every patch ends in a known-good state (applied,
+already-applied, or already-fixed-upstream). It is non-zero only if a patch's
+target file is missing or a patch is genuinely unable to reach a good state, so
+a broken image fails the build loudly instead of silently shipping the bug.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+# --- helper injected into slime/ray/actor_group.py --------------------------
+# Identical in behavior to the upstream fix proposed in the accompanying PR:
+# delegate .so selection to torch_memory_saver's own CUDA-aware resolver, with a
+# loadability-based fallback for older torch_memory_saver builds that predate it.
+_TMS_HELPER = '''
+
+def _resolve_tms_preload_lib(torch_memory_saver):
+    """Path to the torch_memory_saver preload .so that matches the CUDA runtime.
+
+    Prefer the library's own CUDA-aware resolver. Fall back -- for older
+    torch_memory_saver builds that lack it -- to a candidate list that includes
+    the cu<major> variant for the *detected* CUDA major and picks the first that
+    actually loads (existence is not loadability: a cu12 .so exists on a CUDA 13
+    box but cannot be dlopen'd, which is what makes this fail on CUDA 13).
+
+    Injected by awsome-distributed-training patches/apply_slime_patches.py as a
+    stopgap until the equivalent fix lands upstream in THUDM/slime.
+    """
+    import os as _os
+
+    stem = "torch_memory_saver_hook_mode_preload"
+
+    try:
+        from torch_memory_saver.utils import get_binary_path_from_package
+
+        return str(get_binary_path_from_package(stem))
+    except Exception:
+        pass
+
+    import ctypes
+
+    base = _os.path.dirname(_os.path.dirname(torch_memory_saver.__file__))
+    try:
+        import torch
+
+        cuda = getattr(torch.version, "cuda", None)
+        major = cuda.split(".", 1)[0] if cuda else None
+    except Exception:
+        major = None
+
+    candidates = []
+    if major:
+        candidates.append(f"{stem}_cu{major}.abi3.so")
+    candidates += [f"{stem}.abi3.so", f"{stem}_cu12.abi3.so", f"{stem}_cu13.abi3.so"]
+
+    tried = []
+    for name in candidates:
+        path = _os.path.join(base, name)
+        if not _os.path.exists(path):
+            continue
+        try:
+            ctypes.CDLL(path)
+        except OSError as exc:
+            tried.append(f"{name}: {exc}")
+            continue
+        return path
+
+    raise FileNotFoundError(
+        "Could not find a loadable torch_memory_saver preload library for the "
+        f"current CUDA runtime under {base}. Tried: {tried or candidates}"
+    )
+'''
+
+_HELPER_MARKER = "def _resolve_tms_preload_lib("
+
+# The unfixed upstream pattern hard-codes the preload .so filename(s) and selects
+# by existence. We match on the filename token that only appears in that unfixed
+# path; once upstream selects by CUDA runtime, this token is gone and the patch
+# self-neutralizes.
+_BROKEN_TOKEN = '"torch_memory_saver_hook_mode_preload.abi3.so"'
+_ENV_ASSIGN = 'env_vars["LD_PRELOAD"] = dynlib_path'
+_ENV_ASSIGN_REPLACEMENT = (
+    "dynlib_path = _resolve_tms_preload_lib(torch_memory_saver)\n\n"
+    '            env_vars["LD_PRELOAD"] = dynlib_path'
+)
+
+
+class PatchResult:
+    """Outcome of one patch: (status, message). status in known-good set => ok."""
+
+    GOOD = {"applied", "already-applied", "already-fixed-upstream"}
+
+    def __init__(self, name: str, status: str, message: str):
+        self.name = name
+        self.status = status
+        self.message = message
+
+    @property
+    def ok(self) -> bool:
+        return self.status in self.GOOD
+
+    def __str__(self) -> str:
+        flag = "OK " if self.ok else "ERR"
+        return f"[{flag}] {self.name}: {self.status} -- {self.message}"
+
+
+def patch_tms_preload_selection(slime_root: Path) -> PatchResult:
+    """Fix: pick the torch_memory_saver LD_PRELOAD .so by CUDA runtime, not by
+    filename existence (upstream issue/PR: torch_memory_saver cu13 selection).
+
+    On CUDA 13, upstream selects a cu12-linked .so and every child dies with
+    'libcudart.so.12: cannot open shared object file'. See the accompanying
+    SLIME PR for the full analysis.
+    """
+    name = "tms-preload-cuda-aware"
+    target = slime_root / "slime" / "ray" / "actor_group.py"
+    if not target.is_file():
+        return PatchResult(name, "error", f"target not found: {target}")
+
+    src = target.read_text()
+
+    # (a) already patched by us?
+    if _HELPER_MARKER in src:
+        return PatchResult(name, "already-applied", f"{target} already has the helper")
+
+    # (b) upstream already fixed it? The unfixed path is identified by the
+    # hard-coded preload filename token; if it is gone, there is nothing to fix.
+    if _BROKEN_TOKEN not in src:
+        return PatchResult(
+            name,
+            "already-fixed-upstream",
+            "unfixed pattern absent; leaving upstream code untouched",
+        )
+
+    # (c) the assignment site we hang the helper call on must be present and
+    # unique, or we refuse to edit (an unexpected refactor -> skip, do not guess).
+    if src.count(_ENV_ASSIGN) != 1:
+        return PatchResult(
+            name,
+            "error",
+            f'expected exactly one occurrence of `{_ENV_ASSIGN}`, '
+            f"found {src.count(_ENV_ASSIGN)}; refusing to edit",
+        )
+
+    # Insert the helper after the import block (after the last top-level import),
+    # and route the existing assignment through it.
+    lines = src.splitlines(keepends=True)
+    insert_at = 0
+    for i, line in enumerate(lines):
+        if line.startswith(("import ", "from ")):
+            insert_at = i + 1
+    patched = "".join(lines[:insert_at]) + _TMS_HELPER + "".join(lines[insert_at:])
+    patched = patched.replace(_ENV_ASSIGN, _ENV_ASSIGN_REPLACEMENT, 1)
+
+    # Byte-compile to guarantee we did not produce invalid Python.
+    try:
+        compile(patched, str(target), "exec")
+    except SyntaxError as exc:
+        return PatchResult(name, "error", f"patched file fails to compile: {exc}")
+
+    target.write_text(patched)
+    return PatchResult(name, "applied", f"routed LD_PRELOAD through {_HELPER_MARKER[:-1]}()")
+
+
+PATCHES = [
+    patch_tms_preload_selection,
+]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--slime-root",
+        default="/opt/slime",
+        type=Path,
+        help="Path to the upstream SLIME checkout (default: /opt/slime).",
+    )
+    args = ap.parse_args()
+
+    if not args.slime_root.is_dir():
+        print(f"[patch] SLIME root not found: {args.slime_root}", file=sys.stderr)
+        return 2
+
+    print(f"[patch] applying self-neutralizing SLIME patches under {args.slime_root}")
+    results = [patch(args.slime_root) for patch in PATCHES]
+    for r in results:
+        print(f"[patch] {r}")
+
+    failed = [r for r in results if not r.ok]
+    if failed:
+        print(f"[patch] {len(failed)} patch(es) failed", file=sys.stderr)
+        return 1
+    print("[patch] all patches in a known-good state")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/3.test_cases/pytorch/slime/slime.Dockerfile
+++ b/3.test_cases/pytorch/slime/slime.Dockerfile
@@ -180,11 +180,28 @@ RUN pip install --no-cache-dir --force-reinstall --no-deps "${SGL_ROUTER_WHEEL}"
 
 #####################
 # SLIME (RL post-training framework)
+#
+# Installed straight from upstream THUDM/slime at the pinned SLIME_VERSION --
+# no fork, no forked URL. A few upstream bugs still block a clean end-to-end run
+# on CUDA 13; they are healed in the next step against this upstream checkout.
 #####################
 RUN cd /opt && \
     git clone --depth 1 --branch ${SLIME_VERSION} https://github.com/THUDM/slime.git && \
     cd slime && \
     pip install --no-cache-dir -e . --no-deps
+
+#####################
+# Self-neutralizing upstream patches.
+#
+# Applies small, in-place fixes to the upstream SLIME checkout above -- only
+# where the unfixed pattern is actually present. Each patch checks upstream
+# first, so once the corresponding fix lands in THUDM/slime the patch becomes a
+# no-op automatically (no fork to track, no URL to bump; upstream simply wins).
+# The build fails loudly if a patch cannot reach a known-good state. See
+# patches/apply_slime_patches.py for the per-patch rationale and upstream links.
+#####################
+COPY patches/apply_slime_patches.py /opt/slime-patches/apply_slime_patches.py
+RUN python3 /opt/slime-patches/apply_slime_patches.py --slime-root /opt/slime
 
 ## Set Open MPI variables to exclude network interface and conduit.
 ENV OMPI_MCA_pml=^ucx            \


### PR DESCRIPTION
## Purpose

Third fix in the epic to run the SLIME GRPO test case end-to-end on B300 / H200 (tracked by #1163). This merges into the epic branch `epic/enable-slime-grpo-on-b300-h200`, not into `main` directly; the epic is what goes to upstream in #1164.

With the launcher fix (wall 1) and the log-level fix (wall 2) already in the epic, training now starts and the rollout HTTP server binds. The next wall is on the training side: with `--offload-train` on CUDA 13, the train worker dies during startup with `libcudart.so.12: cannot open shared object file`.

## Changes

The bug is in upstream SLIME's [`slime/ray/actor_group.py` L64-L84](https://github.com/THUDM/slime/blob/main/slime/ray/actor_group.py#L64-L84): with `--offload-train` on the Megatron backend it sets `LD_PRELOAD` to a `torch_memory_saver` preload `.so`, choosing the file from a hard-coded list (`..._preload_cu12.abi3.so`, then the unsuffixed `..._preload.abi3.so`) and taking the first that **exists** (`os.path.exists`). On CUDA 13 this is wrong: the `cu12`/unsuffixed builds are byte-identical and both link `libcudart.so.12` (absent on CUDA 13), so `LD_PRELOAD` makes every child — including the train worker — die with `libcudart.so.12: cannot open shared object file`. The correct `cu13` build ships in the same wheel but is never enumerated.

This is upstream SLIME's bug, and I have opened an upstream issue and PR against `THUDM/slime` that fixes it at the source: delegating `.so` selection to `torch_memory_saver`'s own CUDA-aware resolver, [`get_binary_path_from_package`](https://github.com/fzyzcjy/torch_memory_saver/blob/master/torch_memory_saver/utils.py#L58) (the library already uses it internally in [`hooks/mode_preload.py` L27](https://github.com/fzyzcjy/torch_memory_saver/blob/master/torch_memory_saver/hooks/mode_preload.py#L27)). The change here is the test-case-side stopgap until that lands.

The design constraint I set for this stopgap: no fork, no forked URL, and zero maintenance once upstream fixes it. So instead of pointing the image at a fork:

1. [`slime.Dockerfile`](https://github.com/littlemex/awsome-distributed-training/blob/6332009/3.test_cases/pytorch/slime/slime.Dockerfile) keeps installing SLIME straight from upstream `THUDM/slime` at the pinned `SLIME_VERSION` (unchanged).
2. A new [`patches/apply_slime_patches.py`](https://github.com/littlemex/awsome-distributed-training/blob/6332009/3.test_cases/pytorch/slime/patches/apply_slime_patches.py) runs right after the install and rewrites [`actor_group.py`](https://github.com/THUDM/slime/blob/main/slime/ray/actor_group.py#L64-L84) **in place**, applying the exact fix from the upstream PR — but only when the unfixed pattern is present.

The patch is self-neutralizing:

- It first checks whether it has already been applied (helper present) → skips.
- Then whether upstream still has the unfixed pattern (the hard-coded preload filename token) → if that token is gone (i.e. upstream merged the fix, or refactored the selection), it leaves the code untouched and reports `already-fixed-upstream`.
- Only if the unfixed pattern is present does it edit the file, and it byte-compiles the result to guarantee valid Python.

So once the upstream fix lands in `THUDM/slime`, this step becomes a no-op automatically — no fork to track, no URL to bump, nothing to remember. Upstream simply wins. When every patch reports `already-fixed-upstream`, the file can be deleted.

The build fails loudly (non-zero exit) if a patch's target is missing or it cannot reach a known-good state, so the image can never silently ship the unfixed bug.

## Implementation

- `patches/apply_slime_patches.py` — https://github.com/littlemex/awsome-distributed-training/blob/6332009/3.test_cases/pytorch/slime/patches/apply_slime_patches.py
- `slime.Dockerfile` (COPY + RUN after the upstream install) — https://github.com/littlemex/awsome-distributed-training/blob/6332009/3.test_cases/pytorch/slime/slime.Dockerfile#L181-L205
- Commit — https://github.com/littlemex/awsome-distributed-training/commit/6332009

The injected fix is identical in behavior to the upstream PR: prefer [`torch_memory_saver.utils.get_binary_path_from_package("torch_memory_saver_hook_mode_preload")`](https://github.com/fzyzcjy/torch_memory_saver/blob/master/torch_memory_saver/utils.py#L58) (which detects the CUDA major via `torch.version.cuda` in [`_detect_cuda_major`](https://github.com/fzyzcjy/torch_memory_saver/blob/master/torch_memory_saver/utils.py#L21) and returns the matching `_cu<major>` build), with a fallback — for older `torch_memory_saver` that predates that resolver — that builds a candidate list including the detected `cu<major>` variant and selects by **loadability** (`ctypes.CDLL`), not mere existence. The injected helper itself is [`_resolve_tms_preload_lib`](https://github.com/littlemex/awsome-distributed-training/blob/6332009/3.test_cases/pytorch/slime/patches/apply_slime_patches.py) in the patch script.

## Test Plan

This test case runs on Amazon EKS, so verification is done with `kubectl exec` into a Ray worker pod. Every block below is copy-paste-safe: no `<placeholder>` tokens, no shell comment lines inside a command, and no Ray job id required. Set the namespace once:

```bash
export NAMESPACE=<your-namespace>
```

### A. Root-cause proof (deterministic, no GPU, no Ray job)

This is the load-bearing test. It shows both the bug (REPRODUCE) and the fix (VERIFY) in one run, by loading each `.so` selection the way `LD_PRELOAD` would. It does not launch training, so it never depends on a running job or a job id.

```bash
WPOD=$(kubectl -n "$NAMESPACE" get pod -l ray.io/group=gpu-workers -o jsonpath='{.items[0].metadata.name}')
kubectl -n "$NAMESPACE" exec -i "$WPOD" -c ray-worker -- python3 -W ignore - <<'PY'
import os, ctypes, torch, torch_memory_saver
base = os.path.dirname(os.path.dirname(torch_memory_saver.__file__))
def probe(label, path):
    try:
        ctypes.CDLL(path); r = "LOADS OK"
    except OSError as e:
        r = "LOAD FAILS -> " + str(e)
    print(label, "|", os.path.basename(path), "| exists =", os.path.exists(path), "|", r)
print("CUDA (torch.version.cuda) =", torch.version.cuda)
probe("REPRODUCE unfixed pick", os.path.join(base, "torch_memory_saver_hook_mode_preload.abi3.so"))
from torch_memory_saver.utils import get_binary_path_from_package
probe("VERIFY    fixed pick  ", str(get_binary_path_from_package("torch_memory_saver_hook_mode_preload")))
PY
```

Expected output on CUDA 13 — the unfixed selection resolves to a `.so` that exists but cannot load, the fixed selection resolves to the loadable `cu13` build:

```
CUDA (torch.version.cuda) = 13.0
REPRODUCE unfixed pick | torch_memory_saver_hook_mode_preload.abi3.so | exists = True | LOAD FAILS -> libcudart.so.12: cannot open shared object file: No such file or directory
VERIFY    fixed pick   | torch_memory_saver_hook_mode_preload_cu13.abi3.so | exists = True | LOADS OK
```

### B. Patch script behaves correctly (three known-good states)

The patch is deterministic and idempotent, and self-neutralizes once upstream is fixed. This exercises all three states against a scratch copy, so it does not modify the installed tree:

```bash
WPOD=$(kubectl -n "$NAMESPACE" get pod -l ray.io/group=gpu-workers -o jsonpath='{.items[0].metadata.name}')
kubectl -n "$NAMESPACE" exec -i "$WPOD" -c ray-worker -- bash -s <<'EOS'
set -e
rm -rf /tmp/patchtest && mkdir -p /tmp/patchtest/slime/ray
cp /opt/slime/slime/ray/actor_group.py.orig /tmp/patchtest/slime/ray/actor_group.py
echo "=== state 1: apply to unfixed upstream ==="
python3 /opt/slime-patches/apply_slime_patches.py --slime-root /tmp/patchtest
python3 -m py_compile /tmp/patchtest/slime/ray/actor_group.py && echo "py_compile OK"
echo "=== state 2: re-run is idempotent ==="
python3 /opt/slime-patches/apply_slime_patches.py --slime-root /tmp/patchtest
echo "=== state 3: self-neutralize when upstream is already fixed ==="
rm -rf /tmp/patchtest2 && mkdir -p /tmp/patchtest2/slime/ray
sed 's/"torch_memory_saver_hook_mode_preload.abi3.so"/get_binary_path_from_package(stem)/g' \
  /opt/slime/slime/ray/actor_group.py.orig > /tmp/patchtest2/slime/ray/actor_group.py
python3 /opt/slime-patches/apply_slime_patches.py --slime-root /tmp/patchtest2
EOS
```

Expected: state 1 reports `applied` and `py_compile OK`; state 2 reports `already-applied`; state 3 reports `already-fixed-upstream`; all exit 0.

(This assumes the image built with this PR, so `/opt/slime-patches/apply_slime_patches.py` and the `.orig` backup are present. On a tree checked out from the repo, run `python3 3.test_cases/pytorch/slime/patches/apply_slime_patches.py --slime-root <a scratch slime copy>` instead.)

### C. End-to-end (optional)

A full `--offload-train` run is the ultimate confirmation, but it is only meaningful while a job is actually running — an idle cluster logs nothing, so a "no error" result there proves nothing. Test A is the deterministic check reviewers/CI should rely on. If a job is running, confirm the train worker no longer hits the crash by counting `libcudart.so.12` occurrences in its log (expected: 0; before the fix the train worker dies on it right after the rollout servers come up).

## Test Results

Verified on hardware (H200, 2× `p5en.48xlarge`, CUDA 13.0):

- The image builds cleanly from this `slime.Dockerfile`: the patch step runs during the build and reports `tms-preload-cuda-aware: applied` / `all patches in a known-good state`, and the build completes and pushes.
- A container started from that freshly built image (no manual patching) has the fix baked in: `slime/ray/actor_group.py` contains the `_resolve_tms_preload_lib` helper, its selection resolves to `torch_memory_saver_hook_mode_preload_cu13.abi3.so`, and that `.so` `ctypes.CDLL`-loads without error.
- Root-cause probe (Test A above), on a worker:
  ```
  CUDA (torch.version.cuda) = 13.0
  REPRODUCE unfixed pick | torch_memory_saver_hook_mode_preload.abi3.so | exists = True | LOAD FAILS -> libcudart.so.12: cannot open shared object file: No such file or directory
  VERIFY    fixed pick   | torch_memory_saver_hook_mode_preload_cu13.abi3.so | exists = True | LOADS OK
  ```
  i.e. the unfixed selection picks a `.so` that exists but cannot load on CUDA 13; the fixed selection picks the loadable `cu13` build.
- Patch script, all three states (against a scratch copy): `applied` (byte-compiles), `already-applied` (idempotent), `already-fixed-upstream` (leaves upstream untouched) — all exit 0.
- Full `--offload-train` Qwen3-4B run: `libcudart.so.12` errors = 0 (previously the train worker died on it right after the rollout servers came up), and the run advanced past `torch_memory_saver` setup into Megatron init and on into the training loop.

## Blast radius / risk

- Low. The Dockerfile change is one `COPY` + one `RUN` after the existing upstream install; the SLIME pin (`SLIME_VERSION`) and install path are unchanged.
- The patch is a no-op unless the exact unfixed pattern is present, and refuses to edit (reporting an error, which fails the build) if the surrounding code has been refactored in a way it does not recognize — so it cannot silently corrupt the file.
- Nothing runs at container runtime; the healing happens at build time only. `offload_train=False` is unaffected regardless.

## Checklist

- [x] I am working against the epic branch (not `main` directly).
- [x] Default is upstream SLIME; no fork and no forked URL are introduced.
- [x] The patch is self-neutralizing (no-op once upstream merges the fix) and idempotent.
- [x] The build fails loudly if a patch cannot reach a known-good state.
- [x] Verified on hardware (H200 / CUDA 13): the train worker no longer hits `libcudart.so.12` and reaches Megatron init.
- [x] The corresponding upstream fix is filed against `THUDM/slime` (issue + PR) so this stopgap can be removed.
